### PR TITLE
added target-dir to .composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,6 @@
         "psr-0": {
             "MtHamlBundle": ""
         }
-    }
+    },
+    "target-dir": "MtHamlBundle"
 }


### PR DESCRIPTION
composer loaded bundle to "vendor/mthaml/mthaml-bundle" and autoloader don't work

<pre>"Class 'MtHamlBundle\MtHamlBundle' not found"</pre>


I moved sources to "vendor/mthaml/mthaml-bundle/MtHamlBundle" and all work's fine
