### PR TITLE
Added @Haml annotation to controllers

### DIFF
--- a/Controller/Annotations/Haml.php
+++ b/Controller/Annotations/Haml.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MtHamlBundle\Controller\Annotations;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+/**
+ * @Annotation
+ */
+class Haml extends Template
+{
+
+    /**
+     * The haml engine used by default
+     *
+     * @var string
+     */
+    protected $engine = 'haml';
+}

--- a/Tests/Configuration/HamlAnnotationTest.php
+++ b/Tests/Configuration/HamlAnnotationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace MtHamlBundle\Tests\Configuration;
+
+class HamlAnnotationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAnnotation()
+    {
+        $parser = new \Doctrine\Common\Annotations\DocParser();
+        $parser->setImports(array('haml' => '\\MtHamlBundle\\Controller\\Annotations\\Haml'));
+        $annotations = $parser->parse("/**\n* @Haml()\n*/");
+        $this->assertEquals(1, count($annotations));
+        $this->_assertHamlAnnotation($annotations[0]);
+    }
+
+    public function testControllerAnnotation()
+    {
+        $controller = new \MtHamlBundle\Tests\Fixtures\Controller\AnnotatedHamlController();
+        /** @see \Sensio\Bundle\FrameworkExtraBundle\EventListener\ControllerListener::onKernelController() */
+        $reflectionController = new \ReflectionObject($controller);
+        $method = $reflectionController->getMethod('getSomethingAction');
+        $request = new \Symfony\Component\HttpFoundation\Request();
+        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
+        foreach ($reader->getMethodAnnotations($method) as $configuration) {
+            if ($configuration instanceof \Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface) {
+                $request->attributes->set('_' . $configuration->getAliasName(), $configuration);
+            }
+        }
+        $this->_assertHamlAnnotation($request->attributes->get('_template'));
+    }
+
+    protected function _assertHamlAnnotation($hamlTemplateConfiguration)
+    {
+        $this->assertInstanceOf('\\MtHamlBundle\\Controller\\Annotations\\Haml', $hamlTemplateConfiguration);
+        $this->assertEquals('template', $hamlTemplateConfiguration->getAliasName());
+        $this->assertEquals('haml', $hamlTemplateConfiguration->getEngine());
+    }
+}

--- a/Tests/Fixtures/Controller/AnnotatedHamlController.php
+++ b/Tests/Fixtures/Controller/AnnotatedHamlController.php
@@ -1,0 +1,13 @@
+<?php
+namespace MtHamlBundle\Tests\Fixtures\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use MtHamlBundle\Controller\Annotations\Haml;
+
+class AnnotatedHamlController extends Controller
+{
+    /**
+     * @Haml()
+     */
+    public function getSomethingAction()
+    {}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../../../app/bootstrap.php.cache">
+  <php>
+    <!-- <server name="SYMFONY" value="/path/to/symfony" /> -->
+  </php>
+  <testsuites>
+    <testsuite name="FacebookBundle Test Suite">
+      <directory suffix="Test.php">./Tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory>./</directory>
+      <exclude>
+        <directory>./Tests</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>


### PR DESCRIPTION
Hope, this is helpful to use @Haml annotation instead of @Template(engine="haml"). The similar is done in https://github.com/FriendsOfSymfony/FOSRestBundle/tree/master/Controller/Annotations for example. I'm not sure, what is the right way to arrange pull requests in Symfony2 bundles, so I've added phpunit.xml.dist, that works for me.
I believe, analog could be performed for FOSRestBundle to use something like @HamlView instead of @View(engine="haml")
