### PR TITLE
HamlFileExtractor and JMSTranslationBundle extraction

### DIFF
--- a/Resources/config/jms-translation.xml
+++ b/Resources/config/jms-translation.xml
@@ -13,6 +13,9 @@
             <call method="setTwig">
                 <argument type="service" id="twig" />
             </call>
+            <call method="setMtHaml">
+                <argument type="service" id="mthaml" />
+            </call>
             <tag name="jms_translation.file_visitor" />
         </service>
     </services>

--- a/Translation/Extractor/File/HamlFileExtractor.php
+++ b/Translation/Extractor/File/HamlFileExtractor.php
@@ -7,11 +7,24 @@ use JMS\TranslationBundle\Model\MessageCatalogue;
 
 class HamlFileExtractor extends TwigFileExtractor
 {
+    /**
+     * @var \Twig_Environment
+     */
     private $twig;
 
     public function setTwig(\Twig_Environment $twig)
     {
         $this->twig = $twig;
+    }
+
+    /**
+     * @var \MtHaml\Environment
+     */
+    private $mtHaml;
+
+    public function setMtHaml(\MtHaml\Environment $mtHaml)
+    {
+        $this->mtHaml = $mtHaml;
     }
 
     public function visitFile(\SplFileInfo $file, MessageCatalogue $catalogue)
@@ -21,7 +34,9 @@ class HamlFileExtractor extends TwigFileExtractor
 
             if (in_array($extension, array('haml'))) {
                 $args = func_get_args();
-                $args[] = $this->twig->parse($this->twig->tokenize(file_get_contents($file), (string) $file));
+                $code = file_get_contents($file);
+                $code = $this->mtHaml->compileString($code, (string) $file);
+                $args[] = $this->twig->parse($this->twig->tokenize($code, (string) $file));
                 call_user_func_array(array($this, 'visitTwigFile'), $args);
             }
         }


### PR DESCRIPTION
When I wanted to use the HamlFileExtractor with the JMSTranslationBundle, I had a problem extracting the constants from haml templates as the haml code was read from the file and sent to the twig parser right away without compiling it to twig first, therefore no extraction was possible.

As I can see these files haven't been changed in a long time, I suppose some changes in the bundle has broken this.

Unfortunately I had no time to write a test case for this issue. 