### PR TITLE
Fixes the mthaml:debug:dump command

### DIFF
--- a/Command/DebugDumpCommand.php
+++ b/Command/DebugDumpCommand.php
@@ -30,14 +30,8 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $container = $this->getContainer();
-        $loader = $container->get('twig.loader');
-        $env = $container->get('mthaml');
-
-        $templateName = $input->getArgument('template-name');
-
-        $source = $loader->getSource($templateName);
-
-        $output->write($env->compileString($source, $templateName));
+        $output->write(
+            $this->getContainer()->get('twig.loader')->getSource($input->getArgument('template-name'))
+        );
     }
 }


### PR DESCRIPTION
The `mthaml:debug:dump` command was not functional after changing the way MtHaml's services were loaded. Specifically overriding the twig.loader as a proxy for the original twig.loader, in pull request #14, rendered this command broken.

Issue was with the fact that since twig.loader service was overridden, the code was compiled 2 times, during the execution of the command. Obviously the second time it was failing as the input code was already compiled to twig and it was not valid haml.