### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Command/DebugDumpCommand.php
+++ b/Command/DebugDumpCommand.php
@@ -2,13 +2,23 @@
 
 namespace MtHamlBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use MtHaml\Support\Twig\Loader;
 
-class DebugDumpCommand extends ContainerAwareCommand
+class DebugDumpCommand extends Command
 {
+    private $loader;
+
+    public function __construct(Loader $loader)
+    {
+        parent::__construct();
+
+        $this->loader = $loader;
+    }
+
     public function configure()
     {
         $this
@@ -31,7 +41,7 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->write(
-            $this->getContainer()->get('twig.loader')->getSource($input->getArgument('template-name'))
+            $this->loader->getSourceContext($input->getArgument('template-name'))
         );
     }
 }

--- a/Resources/config/mthaml.xml
+++ b/Resources/config/mthaml.xml
@@ -10,6 +10,7 @@
         <parameter key="mthaml.cache_warmer.class">MtHamlBundle\CacheWarmer\TemplateCacheCacheWarmer</parameter>
         <parameter key="mthaml.twig.extension.class">MtHaml\Support\Twig\Extension</parameter>
         <parameter key="mthaml.twig.loader.class">MtHaml\Support\Twig\Loader</parameter>
+        <parameter key="mthaml.command.debug_dump.class">MtHamlBundle\Command\DebugDumpCommand</parameter>
     </parameters>
 
     <services>
@@ -43,6 +44,11 @@
         <service id="mthaml.twig.extension" class="%mthaml.twig.extension.class%" public="false">
             <tag name="twig.extension" alias="mthaml" />
             <argument type="service" id="mthaml" />
+        </service>
+
+        <service id="mthaml.command.debug_dump" class="%mthaml.command.debug_dump.class%" public="false">
+            <tag name="console.command" />
+            <argument type="service" id="twig.loader" />
         </service>
 
     </services>

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^5.3.3|^7.0",
-        "mthaml/mthaml": "~1.3",
+        "mthaml/mthaml": "dev-master",
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/twig-bundle": "~2.3|~3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
         "sensio/framework-extra-bundle": "~2.1|~3.0",
         "symfony/assetic-bundle": "~2.3|~3.0",
         "symfony/console": "~2.3|~3.0",
-        "jms/translation-bundle": "~1.0"
+        "jms/translation-bundle": "~1.0",
+        "symfony/templating": "^5.0",
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
N.B. had to update `mhtaml/mthaml` to `dev-master`, not sure if that's ideal but we need the changes in https://github.com/arnaud-lb/MtHaml/commit/86ebfbe609946859292b4a019f3f7a51af66ead4

Took the liberty of vendoring `phpunit` in the second commit, inspired by https://github.com/arnaud-lb/MtHaml/commit/44dd0199d3fd49e9ba8ec786b459089d89ed2a4b

Had to add `symfony/templating` to get the tests to pass.